### PR TITLE
ci: Updated actions/setup-go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ env:
   BIN_NAME: canow-chain
 
 jobs:
-
   build-binary:
     name: "Node binary"
     strategy:
@@ -24,11 +23,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
-      - uses: actions/setup-go@v3
+
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Build application binary
         run: env VERSION="$( git describe --tags ${{ github.sha }})" CGO_ENABLED=1 GOOS=${{ matrix.goos }} GOARCH=amd64 make build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,45 +5,44 @@ defaults:
   run:
     shell: bash
 
-
 jobs:
-
   sh-euox-pipefail-check:
     name: "Shell pipefail check"
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Run 'set -euox pipefail' check
         run: bash ./.github/scripts/ensure_set_euox_pipefail.sh
-  
+
   md-link-check:
     name: "Broken Markdown links"
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Run Markdown link check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          config-file: '.github/linters/mlc_config.json'
-          use-quiet-mode: 'yes'
-  
+          config-file: ".github/linters/mlc_config.json"
+          use-quiet-mode: "yes"
+
   go-lint:
     # We can't use VALIDATE_GO from super linter because of this issue:
     # https://github.com/github/super-linter/issues/143
     name: "Golang"
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-      
+          cache: false # to bypass https://github.com/golangci/golangci-lint-action/issues/23
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -53,30 +52,30 @@ jobs:
   super-lint:
     name: "Super Linter"
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # Required to fetch version
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to fetch version
 
-    - name: Run Super Linter
-      uses: github/super-linter/slim@v4
-      env:
-        IGNORE_GITIGNORED_FILES: true
-        FILTER_REGEX_EXCLUDE: vue/.*
-        DEFAULT_BRANCH: main
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        LOG_LEVEL: WARN
-        VALIDATE_ALL_CODEBASE: true
-        MULTI_STATUS: true
+      - name: Run Super Linter
+        uses: github/super-linter/slim@v4
+        env:
+          IGNORE_GITIGNORED_FILES: true
+          FILTER_REGEX_EXCLUDE: vue/.*
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          LOG_LEVEL: WARN
+          VALIDATE_ALL_CODEBASE: true
+          MULTI_STATUS: true
 
-        VALIDATE_BASH: true
-        VALIDATE_DOCKERFILE_HADOLINT: true
-        VALIDATE_ENV: true
-        VALIDATE_GITHUB_ACTIONS: true
-        VALIDATE_JSON: true
-        VALIDATE_MARKDOWN: true
-#        VALIDATE_OPENAPI: true
-        VALIDATE_PYTHON_PYLINT: true
-        VALIDATE_XML: true
-        VALIDATE_YAML: true
+          VALIDATE_BASH: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_ENV: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_JSON: true
+          VALIDATE_MARKDOWN: true
+          # VALIDATE_OPENAPI: true
+          VALIDATE_PYTHON_PYLINT: true
+          VALIDATE_XML: true
+          VALIDATE_YAML: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,12 @@ env:
   BIN_NAME: canow-chain
 
 jobs:
-
   release-binary:
     name: "Node binary"
     runs-on: ubuntu-latest
     outputs:
       RELEASE_VERSION: ${{ steps.set-version.outputs.RELEASE_VERSION }}
-    
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -31,10 +30,9 @@ jobs:
           RELEASE_VERSION=$( git describe --tags "${{ github.sha }}")
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Download binary artifacts
         uses: actions/download-artifact@v3
@@ -78,8 +76,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-
-
   release-docker:
     name: "Docker image"
     needs: release-binary
@@ -104,7 +100,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GH_TOKEN }}
-      
+
       - name: Configure Docker image metadata
         id: meta
         uses: docker/metadata-action@v4
@@ -119,7 +115,7 @@ jobs:
           labels: |
             org.opencontainers.image.vendor="Canow"
             org.opencontainers.image.created={{date 'dddd, MMMM Do YYYY, h:mm:ss a'}}
-#            org.opencontainers.image.documentation=""
+          #   org.opencontainers.image.documentation=""
 
       - name: Build and push image
         uses: docker/build-push-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Install ginkgo
         working-directory: ./..
@@ -83,10 +82,9 @@ jobs:
         run: |
           bash import-keys.sh
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Install ginkgo
         working-directory: ./..
@@ -134,15 +132,14 @@ jobs:
       - name: Load new canow-chain Docker image
         run: docker load -i canow-chain-build.tar
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
 
       - name: Install ginkgo
         working-directory: ./..
         run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
-      
+
       # Run tests
       - name: Set up network with old canow-chain version (testnet-latest)
         working-directory: ./tests/upgrade/integration
@@ -234,7 +231,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: report-integration.xml
-      
+
       - name: Download pre-upgrade tests report
         uses: actions/download-artifact@v3
         with:
@@ -249,7 +246,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: report-pricing-proposal.xml
-      
+
       - name: Download pricing change tesst report
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
- Updated `actions/setup-go` to `v4`.
- Set its `cache` parameter to `false` explicitly within `go-lint` job in `Lint` workflow (to avoid https://github.com/golangci/golangci-lint-action/issues/23) because in `v4` it defaults to `true`.
- Removed redundant `cache: true` parameter from `actions/setup-go` within all the other jobs.